### PR TITLE
clear INT1 during initialization

### DIFF
--- a/drivers/input/misc/l3g42xxd.c
+++ b/drivers/input/misc/l3g42xxd.c
@@ -241,6 +241,9 @@ static int l3g42xxd_init_chip(struct l3g42xxd_chip* chip){
     err = l3g42xxd_set_sample_rate(chip,L3GD42XXD_ODR_95);
     err = l3g42xxd_set_fs_range(chip,L3GD42XXD_FS_2000);
 
+    // clear the INT1 device line in case it is stuck high after the processor reset
+    chip->read(chip->dev,L3G42XXD_INTERRUPT_SRC);
+
     return 0;
 }
 


### PR DESCRIPTION
The gyro does not have a reset line, so if the main processor
is suddenly reset, then the INT1 may get stuck at 1 after reset
=> no interrupt will ever be seen by the processor after it
boots again