### PR TITLE
Add a workaround for logitech c510 webcam

### DIFF
--- a/drivers/media/video/uvc/uvc_video.c
+++ b/drivers/media/video/uvc/uvc_video.c
@@ -92,6 +92,10 @@ static void uvc_fixup_video_ctrl(struct uvc_streaming *stream,
 	struct uvc_format *format = NULL;
 	struct uvc_frame *frame = NULL;
 	unsigned int i;
+	
+	// Workaround for TRIK-specific musb implementation
+	// and Logitech c510 webcam
+	ctrl->dwMaxPayloadTransferSize = 600;
 
 	for (i = 0; i < stream->nformats; ++i) {
 		if (stream->format[i].index == ctrl->bFormatIndex) {


### PR DESCRIPTION
musb controller on the TRIK board does not support high bandwidth
isochronuos USB transfers, but c510 webcam does not provide
appropriate endpoints for non-HB video transfer. So limit max transfer
block size and pray that it won't break anything.