### PR TITLE
Hotfix: ignore CD signal for mmc0

### DIFF
--- a/arch/arm/mach-davinci/board-da850-trik.c
+++ b/arch/arm/mach-davinci/board-da850-trik.c
@@ -179,7 +179,9 @@ static const short da850_trik_sd0_pins[] __initconst = {
 
 static int da850_trik_sd0_get_cd(int index)
 {
-	return !gpio_get_value(GPIO_TO_PIN(4,1));
+	// Hotfix for broken boards
+	return 1;
+//	return !gpio_get_value(GPIO_TO_PIN(4,1));
 }
 
 static struct davinci_mmc_config da850_trik_sd0_config = {


### PR DESCRIPTION
Some boards are broken, so employ a quick-and-dirty hack.